### PR TITLE
Refactor HrView component: change attribute display from h6 to p for …

### DIFF
--- a/frontend/src/pages/HrView.jsx
+++ b/frontend/src/pages/HrView.jsx
@@ -165,10 +165,11 @@ const HrView = () => {
           {coustumattributes && coustumattributes.length > 0 ? (
             <div>
             {coustumattributes.map((attribute, index) => (
-              <h6 key={index}>
+              <p key={index}>
                 {attribute.key_name} : {attribute.value}
                 
-              </h6>
+                
+              </p>
             ))}
           </div>
           ) : (


### PR DESCRIPTION
This pull request includes a small change to the `HrView` component in `frontend/src/pages/HrView.jsx`. The change modifies the HTML elements used to display custom attributes.

* [`frontend/src/pages/HrView.jsx`](diffhunk://#diff-f6678ce48f1ea8598512d91b0ecfb6a84e0c1df4194d4ae28e9fc568b6b12e2dL168-R172): Changed the HTML element from `<h6>` to `<p>` for displaying custom attributes in the `HrView` component.…better semantics